### PR TITLE
add string.h as include to remove implicit declaration errors

### DIFF
--- a/src/nextwall.c
+++ b/src/nextwall.c
@@ -29,6 +29,7 @@
 #include <glib/gstdio.h>
 #include <locale.h>
 #include <stdlib.h>
+#include <string.h> /* for strcpy strcat strerr strcmp */
 #include <time.h>
 #include <readline/readline.h>
 #include <readline/history.h>


### PR DESCRIPTION
The following functions are used in `nextwall.c`:
- `strcpy`
- `strcmp`
- `strerr`
- `strcat`

These all gave an error because the were not explicitly declared.

This pull request adds the explicit declarations for string functions by including `string.h`.
